### PR TITLE
新着メッセージからプロフィールへ遷移できる

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,8 +1,11 @@
 class ProfilesController < ApplicationController
-  before_action :authenticate_user!
-  before_action :set_profile
+  before_action :authenticate_user!, except: [:show]
+  before_action :set_profile, only: [:edit, :update]
+  before_action :set_user_profile, only: [:show]
 
   def show
+    @tree = @user.tree
+    @messages_count = @user.messages.count
   end
 
   def edit
@@ -20,6 +23,11 @@ class ProfilesController < ApplicationController
 
   def set_profile
     @profile = current_user.profile
+  end
+
+  def set_user_profile
+    @user = User.find(params[:id])
+    @profile = @user.profile
   end
 
   def profile_params

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -30,8 +30,10 @@
           <p class="text-sm text-gray-600 mt-1"><%= truncate(message.content, length: 50) %></p>
           <div class="flex justify-between items-center mt-2">
             <span class="text-xs text-gray-500"><%= message.created_at.strftime("%Y-%m-%d %H:%M") %></span>
-            <span class="text-xs text-gray-500"><%= message.user.name %></span>
-          </div>
+            <%= link_to user_profile_path(message.user), class: "text-xs text-blue-500 hover:underline" do %>
+              <%= message.user.name %>
+            <% end %>
+         </div>
         </div>
       <% end %>
     </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -7,8 +7,10 @@
         <p class="mb-2 text-gray-600">ユーザー名</p>
         <p class="font-semibold mb-4"><%= @profile.username %></p>
         <div class="w-32 h-32 bg-gray-300 rounded-full mx-auto mb-4"></div>
-        <%= link_to 'プロフィール編集', edit_user_registration_path, class: 'w-full bg-gray-200 hover:bg-gray-300 py-2 rounded text-center block mb-4 transition duration-300' %>
-        <%= link_to '木のカスタマイズ', '#', class: 'w-full bg-gray-200 hover:bg-gray-300 py-2 rounded text-center block transition duration-300' %>
+        <% if current_user == @profile.user %>
+          <%= link_to 'プロフィール編集', edit_user_registration_path, class: 'w-full bg-gray-200 hover:bg-gray-300 py-2 rounded text-center block mb-4 transition duration-300' %>
+          <%= link_to '木のカスタマイズ', '#', class: 'w-full bg-gray-200 hover:bg-gray-300 py-2 rounded text-center block transition duration-300' %>
+        <% end %>
       </div>
     </aside>
 
@@ -22,11 +24,13 @@
           </div>
           <p class="mt-4 text-center text-gray-600">現在の成長段階: <%= t("tree.stages.#{@profile.user.tree.current_stage}") %></p>
         <% else %>
-          <p class="text-center text-gray-600">まだメッセージがありません。新しいメッセージを作成して、木を成長させましょう。</p>
+          <p class="text-center text-gray-600">まだメッセージがありません。</p>
         <% end %>
-        <div class="text-center mt-6">
-          <%= link_to '新しいメッセージを作成', new_message_path, class: 'inline-block bg-teal-500 hover:bg-teal-600 text-white font-bold py-2 px-4 rounded transition duration-300' %>
-        </div>
+        <% if current_user == @profile.user %>
+          <div class="text-center mt-6">
+            <%= link_to '新しいメッセージを作成', new_message_path, class: 'inline-block bg-teal-500 hover:bg-teal-600 text-white font-bold py-2 px-4 rounded transition duration-300' %>
+          </div>
+        <% end %>
         <p class="mt-4 text-center text-gray-600">メッセージ数: <%= @profile.user.messages.count %></p>
       </div>
     </main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   get 'home', to: 'home#index', as: :home
   resources :messages
   resources :profiles, only: [:show, :edit, :update]
+  get 'users/:id/profile', to: 'profiles#show', as: :user_profile
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
## 実装したこと
・新着メッセージから他のユーザーのプロフィールページに遷移できる機能
・新着メッセージのユーザー名のリンクから遷移。
・他ユーザーのユーザー名、木の成長具合などを閲覧可能。
・自身と他人のプロフィールページの区別。